### PR TITLE
path()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Support for http-interop/http-server-middleware and http-interop/http-server-handler
+- `path()` utility function that decorates a middleware and only runs it if the incoming
+request URI matches the required given path prefix.
 
 ### Changed
 


### PR DESCRIPTION
Implements a `path()` function that decorates a middleware and only runs it if the incoming request URI matches the required path prefix.

As discussed in https://github.com/zendframework/zend-stratigility/pull/134