### PR TITLE
Rename php-coveralls binary to match php-coveralls 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction"
-    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,6 @@
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
-        "upload-coverage": "coveralls -v"
+        "upload-coverage": "php-coveralls -v"
     }
 }


### PR DESCRIPTION
Since `php-coveralls` renamed their binary in 2.0 release.